### PR TITLE
fix(makefile): guard release target against a pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ update:
 #release: @ Create and push a new tag
 release:
 	$(eval NT=$(NEWTAG))
+	@if git rev-parse -q --verify "refs/tags/${NT}" >/dev/null 2>&1; then echo "ERROR: tag ${NT} already exists locally. Pick a new version or delete it: git tag -d ${NT}"; exit 1; fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/${NT}" >/dev/null 2>&1; then echo "ERROR: tag ${NT} already exists on origin. Pick a new version."; exit 1; fi
 	@echo -n "Are you sure to create and push ${NT} tag? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@echo ${NT} > ./version.txt
 	@git add -A


### PR DESCRIPTION
The `release` target wrote `version.txt` and ran `git commit` before `git tag ${NT}` with no check that the tag was free. Re-running with an already-existing tag left a dangling "Cut X release" commit while `git tag` aborted (Makefile Safety Check #16).

This adds local (`git rev-parse --verify`) and remote (`git ls-remote`) tag pre-existence checks right after the tag string is known and before the confirm prompt / any mutation, failing fast with an actionable message.

Verified: `make -n release` parses; `make release NEWTAG=v0.0.1` (an existing tag) errors at the guard before writing version.txt or committing, leaving the tree clean.